### PR TITLE
Move micro-infra-spring version to gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     currentVersion = "${versionPrefix}-${buildNrLoc}"
     
     jacksonMapper = '1.9.13'
-    microInfraSpringVersion = '0.8.3'
+    //microInfraSpring version moved to gradle.properties
 }
 
 uploadArchives {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+microInfraSpringVersion=0.8.3


### PR DESCRIPTION
To make it easier to make acceptance tests on CI.
